### PR TITLE
Implement plot well selection toggle

### DIFF
--- a/src/components/PlotArea.tsx
+++ b/src/components/PlotArea.tsx
@@ -3,7 +3,7 @@ import { Sparkline } from './Sparkline'
 import { useAssayStore } from '../features/hooks'
 
 export const PlotArea: React.FC = () => {
-  const { rawData, selectedWells, results } = useAssayStore()
+  const { rawData, selectedWells, results, setSelectedWells } = useAssayStore()
 
   const rows = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
   const cols = Array.from({ length: 12 }, (_, i) => i + 1)
@@ -27,8 +27,13 @@ export const PlotArea: React.FC = () => {
   }
 
   const handleWellClick = (wellId: string) => {
-    // TODO: Implement well selection toggle
-    console.log('Clicked well:', wellId)
+    const newSelected = new Set(selectedWells)
+    if (newSelected.has(wellId)) {
+      newSelected.delete(wellId)
+    } else {
+      newSelected.add(wellId)
+    }
+    setSelectedWells(newSelected)
   }
 
   // 计算全局最大Y值和最小Y值

--- a/src/tests/PlotArea.test.tsx
+++ b/src/tests/PlotArea.test.tsx
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { PlotArea } from '../components/PlotArea'
+import { useAssayStore } from '../features/hooks'
+
+vi.mock('../features/hooks', () => ({
+  useAssayStore: vi.fn()
+}))
+
+const mockSetSelectedWells = vi.fn()
+
+const baseStore = {
+  rawData: [{ wellId: 'A1', timePoints: [0, 1, 2] }],
+  results: [],
+  setSelectedWells: mockSetSelectedWells
+}
+
+describe('PlotArea well selection', () => {
+  beforeEach(() => {
+    mockSetSelectedWells.mockClear()
+  })
+
+  it('selects well on click', () => {
+    (useAssayStore as any).mockReturnValue({
+      ...baseStore,
+      selectedWells: new Set()
+    })
+    const { container } = render(<PlotArea />)
+    const plot = container.querySelector('.cursor-pointer') as HTMLElement
+    fireEvent.click(plot)
+    const newSet = mockSetSelectedWells.mock.calls[0][0] as Set<string>
+    expect(newSet.has('A1')).toBe(true)
+  })
+
+  it('deselects well on second click', () => {
+    (useAssayStore as any).mockReturnValue({
+      ...baseStore,
+      selectedWells: new Set(['A1'])
+    })
+    const { container } = render(<PlotArea />)
+    const plot = container.querySelector('.cursor-pointer') as HTMLElement
+    fireEvent.click(plot)
+    const newSet = mockSetSelectedWells.mock.calls[0][0] as Set<string>
+    expect(newSet.has('A1')).toBe(false)
+  })
+})

--- a/src/types/clsx.d.ts
+++ b/src/types/clsx.d.ts
@@ -1,0 +1,1 @@
+declare module 'clsx';


### PR DESCRIPTION
## Summary
- toggle well selection in PlotArea
- use the toggle when clicking sparklines
- add PlotArea tests confirming selection changes
- stub `clsx` for TypeScript

## Testing
- `npm run lint`
- `npm run type-check`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68845a5a75ec83249fd77b2845801736