### PR TITLE
Add data preview table

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,14 @@ src/
 
 1. **Select Assay Type**: Choose between T2943, S2251, or HoFF
 2. **Paste CSV Data**: Paste your 96-well plate data in CSV format
-3. **Select Wells**: Use the well selector to choose wells for analysis
-4. **Configure Controls**: For S2251 and HoFF, select control wells
-5. **Set Parameters**: Adjust time range and smoothing window
-6. **Calculate**: Click calculate to run the analysis
-7. **View Results**: See the calculated metrics for each well
-8. **Visualize Data**: View time series plots for all wells
-9. **Export Results**: Download results in CSV or XLSX format
+3. **Preview Parsed Data**: A small table shows the first few wells and time points
+4. **Select Wells**: Use the well selector to choose wells for analysis
+5. **Configure Controls**: For S2251 and HoFF, select control wells
+6. **Set Parameters**: Adjust time range and smoothing window
+7. **Calculate**: Click calculate to run the analysis
+8. **View Results**: See the calculated metrics for each well
+9. **Visualize Data**: View time series plots for all wells
+10. **Export Results**: Download results in CSV or XLSX format
 
 ### Sample Data
 

--- a/src/components/DataPreviewTable.tsx
+++ b/src/components/DataPreviewTable.tsx
@@ -1,0 +1,51 @@
+import React from 'react'
+import { WellData } from '../features/hooks'
+
+interface DataPreviewTableProps {
+  data: WellData[]
+  maxWells?: number
+  maxPoints?: number
+}
+
+export const DataPreviewTable: React.FC<DataPreviewTableProps> = ({
+  data,
+  maxWells = 5,
+  maxPoints = 5
+}) => {
+  const wells = data.slice(0, maxWells)
+  const showEllipsisRows = data.length > maxWells
+  const showEllipsisCols = wells[0]?.timePoints.length > maxPoints
+
+  return (
+    <div className="overflow-auto border rounded bg-white max-h-60">
+      <table className="min-w-[400px] text-sm" role="table">
+        <thead>
+          <tr>
+            <th className="px-2 py-1 text-left sticky left-0 bg-white">Well</th>
+            {Array.from({ length: Math.min(maxPoints, wells[0]?.timePoints.length || 0) }, (_, i) => (
+              <th key={i} className="px-2 py-1 text-right">T{i}</th>
+            ))}
+            {showEllipsisCols && <th className="px-2 py-1">…</th>}
+          </tr>
+        </thead>
+        <tbody>
+          {wells.map(well => (
+            <tr key={well.wellId}>
+              <td className="px-2 py-1 font-mono sticky left-0 bg-white">{well.wellId}</td>
+              {well.timePoints.slice(0, maxPoints).map((v, idx) => (
+                <td key={idx} className="px-2 py-1 text-right font-mono">{v}</td>
+              ))}
+              {showEllipsisCols && <td className="px-2 py-1 text-right">…</td>}
+            </tr>
+          ))}
+          {showEllipsisRows && (
+            <tr>
+              <td className="px-2 py-1" colSpan={maxPoints + 2}>…</td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+    </div>
+  )
+}
+

--- a/src/components/PasteTable.tsx
+++ b/src/components/PasteTable.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useCallback } from 'react'
 import { useAssayStore, WellData } from '../features/hooks'
+import { DataPreviewTable } from './DataPreviewTable'
 
 export const PasteTable: React.FC = () => {
   const { rawData, setRawData, setErrors, setSelectedWells, timeRange, errors } = useAssayStore()
@@ -139,7 +140,9 @@ export const PasteTable: React.FC = () => {
         </div>
       )}
 
-      {/* 移除预览区域 */}
+      {rawData.length > 0 && (
+        <DataPreviewTable data={rawData} />
+      )}
     </div>
   )
 } 

--- a/src/components/PlateResultsGrid.tsx
+++ b/src/components/PlateResultsGrid.tsx
@@ -1,6 +1,5 @@
 import { memo } from "react";
 import { useAssayStore } from "../features/hooks"; // Zustand store
-import clsx from "clsx";
 
 const COLS = Array.from({ length: 12 }, (_, i) => i + 1);
 const ROWS = ["A","B","C","D","E","F","G","H"];
@@ -53,10 +52,9 @@ const PlateResultsGrid = memo(() => {
                     return (
                       <td
                         key={id}
-                        className={clsx(
-                          "h-6 w-8 text-center border border-gray-300",
-                          Number.isFinite(val) ? "text-gray-900" : "text-gray-400"
-                        )}
+                        className={`h-6 w-8 text-center border border-gray-300 ${
+                          Number.isFinite(val) ? 'text-gray-900' : 'text-gray-400'
+                        }`}
                       >
                         {Number.isFinite(val) ? val.toFixed(sigDigits) : "—"}
                       </td>

--- a/src/tests/PasteTable.test.tsx
+++ b/src/tests/PasteTable.test.tsx
@@ -100,8 +100,31 @@ describe('PasteTable', () => {
 
   it('updates placeholder text based on time range', () => {
     render(<PasteTable />)
-    
+
     const textarea = screen.getByRole('textbox')
     expect(textarea).toHaveAttribute('placeholder', expect.stringContaining('30 data points (0-29 minutes)'))
   })
-}) 
+
+  it('shows preview table after valid input', () => {
+    const mockStore: any = {
+      rawData: [],
+      timeRange: [0, 30],
+      errors: [],
+      setRawData: (data: any) => {
+        mockStore.rawData = data
+      },
+      setErrors: mockSetErrors,
+      setSelectedWells: mockSetSelectedWells
+    }
+    ;(useAssayStore as any).mockReturnValue(mockStore)
+    const { rerender } = render(<PasteTable />)
+
+    const textarea = screen.getByRole('textbox')
+    const testData = `A1,${Array.from({ length: 30 }, (_, i) => i + 1).join(',')}`
+    fireEvent.change(textarea, { target: { value: testData } })
+
+    rerender(<PasteTable />)
+
+    expect(screen.getByRole('table')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary
- preview parsed data in a new `DataPreviewTable`
- show preview in `PasteTable`
- document the preview step in README
- remove unused clsx dependency
- test preview rendering

## Testing
- `npm run quick-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68845a5358a88324a461db4d063dccf3